### PR TITLE
add github.com/tidwall/pretty dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.15
 require (
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/tidwall/gjson v1.7.3 // indirect
+	github.com/tidwall/pretty v1.1.0 // indirect
 	github.com/tidwall/sjson v1.1.5 // indirect
 )


### PR DESCRIPTION
The command `go build github.com/tidwall/jj/cmd/jj` reports the following error:

```
go: github.com/tidwall/jj/cmd/jj: package github.com/tidwall/pretty imported from implicitly required module; to add missing requirements, run:
	go get github.com/tidwall/pretty@v1.1.0
```
